### PR TITLE
Use OkHttp to avoid connection issues in some android versions

### DIFF
--- a/org.eclipse.egit.github.core/pom-jar.xml
+++ b/org.eclipse.egit.github.core/pom-jar.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.eclipse.mylyn.github</groupId>
 	<artifactId>org.eclipse.egit.github.core</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.1-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.sonatype.oss</groupId>
@@ -187,5 +187,11 @@
 			<version>2.2.2</version>
 			<scope>compile</scope>
 		</dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>1.5.4</version>
+            <scope>compile</scope>
+        </dependency>
 	</dependencies>
 </project>

--- a/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/client/GitHubClient.java
+++ b/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/client/GitHubClient.java
@@ -46,6 +46,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 import org.eclipse.egit.github.core.RequestError;
+import org.eclipse.egit.github.core.okhttp.OkHttpProvider;
 import org.eclipse.egit.github.core.util.EncodingUtils;
 
 /**
@@ -254,7 +255,7 @@ public class GitHubClient {
 	 */
 	protected HttpURLConnection createConnection(String uri) throws IOException {
 		URL url = new URL(createUri(uri));
-		return (HttpURLConnection) url.openConnection();
+        return OkHttpProvider.getOkHttpClient().open(url);
 	}
 
 	/**

--- a/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/okhttp/OkHttpProvider.java
+++ b/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/okhttp/OkHttpProvider.java
@@ -1,0 +1,11 @@
+package org.eclipse.egit.github.core.okhttp;
+
+import com.squareup.okhttp.OkHttpClient;
+
+public class OkHttpProvider {
+    private static final OkHttpClient sOkHttpClient = new OkHttpClient();
+
+    public static OkHttpClient getOkHttpClient(){
+        return sOkHttpClient;
+    }
+}

--- a/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/util/MultiPartUtils.java
+++ b/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/util/MultiPartUtils.java
@@ -10,6 +10,8 @@
  *****************************************************************************/
 package org.eclipse.egit.github.core.util;
 
+import org.eclipse.egit.github.core.okhttp.OkHttpProvider;
+
 import static org.eclipse.egit.github.core.client.IGitHubConstants.CHARSET_UTF8;
 
 import java.io.BufferedOutputStream;
@@ -35,8 +37,7 @@ public class MultiPartUtils {
 	 */
 	public static HttpURLConnection post(String url, Map<String, Object> parts)
 			throws IOException {
-		HttpURLConnection post = (HttpURLConnection) new URL(url)
-				.openConnection();
+		HttpURLConnection post = OkHttpProvider.getOkHttpClient().open(new URL(url));
 		post.setRequestMethod("POST"); //$NON-NLS-1$
 		return post(post, parts);
 	}


### PR DESCRIPTION
see: https://github.com/slapperwan/gh4a/issues/181

The Issue: http://stackoverflow.com/questions/11810447/httpurlconnection-worked-fine-in-android-2-x-but-not-in-4-1-no-authentication-c

Solution: use http://square.github.io/okhttp/ . Their implementation correctly handles this issue
